### PR TITLE
【質問】webpackerエラーのエラーを解決したい

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   plugins: [
-    require('tailwindcss'),
-    require('autoprefixer'),
     require('postcss-import'),
     require('postcss-flexbugs-fixes'),
     require('postcss-preset-env')({


### PR DESCRIPTION
### 質問内容・実現したいこと
webpackerのエラーを解消したいです。

### 現状発生している問題・エラーメッセージ
[![Image from Gyazo](https://i.gyazo.com/bbc7b1af3a75845cd613ebfdfbe4580d.png)](https://gyazo.com/bbc7b1af3a75845cd613ebfdfbe4580d)
[![Image from Gyazo](https://i.gyazo.com/cde2df18af95e50cfa7dc582f2060017.png)](https://gyazo.com/cde2df18af95e50cfa7dc582f2060017)


### 該当のソースコード

app/config/webpacker.yml
```
# Note: You must restart bin/webpack-dev-server for changes to take effect

default: &default
  source_path: app/javascript
  source_entry_path: packs
  public_root_path: public
  public_output_path: packs
  cache_path: tmp/cache/webpacker
  webpack_compile_output: true

  # Additional paths webpack should lookup modules
  # ['app/assets', 'engine/foo/app/assets']
  additional_paths: []

  # Reload manifest.json on all requests so we reload latest compiled packs
  cache_manifest: false

  # Extract and emit a css file
  extract_css: false

  static_assets_extensions:
    - .jpg
    - .jpeg
    - .png
    - .gif
    - .tiff
    - .ico
    - .svg
    - .eot
    - .otf
    - .ttf
    - .woff
    - .woff2

  extensions:
    - .mjs
    - .js
    - .sass
    - .scss
    - .css
    - .module.sass
    - .module.scss
    - .module.css
    - .png
    - .svg
    - .gif
    - .jpeg
    - .jpg

development:
  <<: *default
  compile: true

  # Reference: https://webpack.js.org/configuration/dev-server/
  dev_server:
    https: false
    host: localhost
    port: 3035
    public: localhost:3035
    hmr: false
    # Inline should be set to true if using HMR
    inline: true
    overlay: true
    compress: true
    disable_host_check: true
    use_local_ip: false
    quiet: false
    pretty: false
    headers:
      'Access-Control-Allow-Origin': '*'
    watch_options:
      ignored: '**/node_modules/**'


test:
  <<: *default
  compile: true

  # Compile test packs to a separate directory
  public_output_path: packs-test

production:
  <<: *default

  # Production depends on precompilation of packs prior to booting for performance.
  compile: false

  # Extract and emit a css file
  extract_css: true

  # Cache manifest.json for performance
  cache_manifest: true

```

public/packs/manifest.json
```
{
  "entrypoints": {
    "login": {
      "js": [
        "/packs/js/login-045721f2bc8815c8cb05.js"
      ],
      "js.map": [
        "/packs/js/login-045721f2bc8815c8cb05.js.map"
      ]
    }
  },
  "login.js": "/packs/js/login-045721f2bc8815c8cb05.js",
  "login.js.map": "/packs/js/login-045721f2bc8815c8cb05.js.map"
}
```

app/javascript/application.js
```
// Entry point for the build script in your package.json
import "styleseets/application"

import Rails from "@rails/ujs"
import Turbolinks from "turbolinks"
import * as ActiveStorage from "@rails/activestorage"
import "channels"
import "../css/tailwind.css"
import "../../assets/stylesheets/application.css"

Rails.start()
Turbolinks.start()
ActiveStorage.start()
```
Gemfile
```
gem 'webpacker', '~> 5.0'
```



### 試したこと

エラー文の1のwebpacker.ymlのcompileはtrueになっていると確認しました。

webpackerのインストールとコンパイルしたら治ったとの記事があったので行いましたが、解決出来ずです。
```
yarn add @rails/webpacker
rails webpacker:install
rails webpacker:compile
```

### 参考にしたURL

https://qiita.com/ginger-yell/items/8584e9149496940ea144
https://techblg.app/articles/handle-webpacker-manifest-missing-entry-error/
https://kabacho23.hatenablog.com/entry/2021/03/07/%3CRuby_on_Rails%3E_Webpacker%3A%3AManifest%3A%3AMissingEntryError
